### PR TITLE
Fixes registry issue in e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,11 +452,12 @@ info: ## displays setup information
 	@echo ' DIRECTOR_API_VERSION  : ${DIRECTOR_API_VERSION}'
 	@echo ' STORAGE_API_VERSION   : ${STORAGE_API_VERSION}'
 	@echo ' WEBSERVER_API_VERSION : ${WEBSERVER_API_VERSION}'
-	# tools version
+	# dev tools version
 	@echo ' make   : $(shell make --version 2>&1 | head -n 1)'
 	@echo ' jq     : $(shell jq --version)'
 	@echo ' awk    : $(shell awk -W version 2>&1 | head -n 1)'
 	@echo ' python : $(shell python3 --version)'
+	@echo ' node   : $(shell node --version 2> /dev/null || echo ERROR nodejs missing)'
 
 
 define show-meta

--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ endif
 
 .PHONY: clean clean-images clean-venv clean-all clean-more
 
-_git_clean_args := -dxf -e .vscode -e TODO.md -e .venv
+_git_clean_args := -dxf -e .vscode -e TODO.md -e .venv -e .python-version
 _running_containers = $(shell docker ps -aq)
 
 .check-clean:

--- a/scripts/install_nodejs_14.bash
+++ b/scripts/install_nodejs_14.bash
@@ -1,0 +1,21 @@
+#
+# Install Node.js 14 on Ubuntu
+#
+# Requirements for development machines
+#
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+IFS=$'\n\t'
+
+sudo apt update
+
+# Script to install the NodeSource Node.js 14.x repo onto a Debian or Ubuntu system
+curl -sL https://deb.nodesource.com/setup_14.x | sudo bash -
+
+# Verify new source
+cat /etc/apt/sources.list.d/nodesource.list
+
+# Installs node-js
+apt-get install -y nodejs

--- a/services/docker-compose-ops.yml
+++ b/services/docker-compose-ops.yml
@@ -71,7 +71,9 @@ services:
       - simcore_default
 
   flower:
-    image: mher/flower:latest
+    # NOTE: latest with DIGEST 9bcc31818a1c7 is broken!
+    # SEE https://github.com/mher/flower/issues/1029
+    image: mher/flower:0.9.5
     init: true
     restart: always
     environment:


### PR DESCRIPTION
Fixes registry step in e2e CI. The problem was that ``wait_for_sercices.py`` will fail since the latest release of ``flower`` was actually broken. 

- Froze flower service in ops to latest working version
- Improved logging and checks reliability in ``tests/e2e/utils/wait_for_services.py``
- Small convenience improvements to help running in newly development machines