### PR TITLE
Sanderegg is1875/director2managescompservices

### DIFF
--- a/services/director-v2/docker-compose-extra.yml
+++ b/services/director-v2/docker-compose-extra.yml
@@ -49,7 +49,7 @@ services:
     image: portainer/portainer
     init: true
     ports:
-      - "9000:9000"
+      - "9010:9000"
     command: -H unix:///var/run/docker.sock
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/services/director-v2/src/simcore_service_director_v2/__main__.py
+++ b/services/director-v2/src/simcore_service_director_v2/__main__.py
@@ -6,6 +6,7 @@
 import sys
 from pathlib import Path
 
+import dotenv
 import uvicorn
 from fastapi import FastAPI
 from simcore_service_director_v2.core.application import init_app
@@ -13,6 +14,9 @@ from simcore_service_director_v2.core.settings import AppSettings, BootModeEnum
 
 current_dir = Path(sys.argv[0] if __name__ == "__main__" else __file__).resolve().parent
 
+# NOTE: since some versions until now, this seems to be necessary to load .env file (used in make run-devel)
+# SEE https://github.com/tiangolo/fastapi/issues/2336
+dotenv.load_dotenv(verbose=True)
 
 # SINGLETON FastAPI app
 the_app: FastAPI = init_app()

--- a/services/director-v2/src/simcore_service_director_v2/utils/computations.py
+++ b/services/director-v2/src/simcore_service_director_v2/utils/computations.py
@@ -14,8 +14,8 @@ log = logging.getLogger(__file__)
 def get_pipeline_state_from_task_states(
     tasks: List[CompTaskAtDB], publication_timeout: int
 ) -> RunningState:
+    """ Determines the state of the pipeline by checking the state of every task """
 
-    # compute pipeline state from task states
     now = datetime.utcnow()
     if tasks:
         # put in a set of unique values


### PR DESCRIPTION
- fixes ``make run-devel`` recipe
- Changes mapped port of portainer **for manual testing** since 900X are taken by jupyter in vscode