### PR TITLE
Sanderegg maintenance/add consistency scripts

### DIFF
--- a/scripts/maintenance/check_consistency_data.py
+++ b/scripts/maintenance/check_consistency_data.py
@@ -122,11 +122,16 @@ def main(
                     # DATE_creation? size node_id/file_path.ext
                     list_of_files = completed_process.stdout.decode("UTF-8").split("\n")
                     for file in list_of_files:
-                        s3_file_entries.add(re.findall(r".* (.+)", file))
+                        partial_file_path = re.findall(r".* (.+)", file)
+                        s3_file_entries.add(f"{project_uuid}/{partial_file_path}")
 
             except subprocess.CalledProcessError:
                 pass
-
+    s3_file_entries_path = Path.cwd() / "s3_file_entries.txt"
+    s3_file_entries_path.write_text("\n".join(s3_file_entries))
+    typer.echo(
+        f"processed {len(project_nodes)} projects, found {len(s3_file_entries)} file entries, saved in {s3_file_entries_path}"
+    )
     import pdb
 
     pdb.set_trace()

--- a/scripts/maintenance/check_consistency_data.py
+++ b/scripts/maintenance/check_consistency_data.py
@@ -1,0 +1,160 @@
+#! /usr/bin/env python3
+
+"""Script to check consistency of the file storage backend in oSparc.
+
+
+
+    1. From an osparc database, go over all projects, get the project IDs and Node IDs
+    2. From the same database, now get all the files listed like projectID/nodeID from 1.
+    3. We get a list of files that are needed for the current projects
+    4. connect to the S3 backend, check that these files exist
+    5. generate a report with: project uuid, owner, files missing in S3
+"""
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import psycopg2
+import typer
+
+
+def main(
+    postgres_volume_name: str,
+    postgres_username: str,
+    postgres_password: str,
+    s3_endpoint: str,
+    s3_access: str,
+    s3_secret: str,
+    s3_bucket: str,
+):
+    # setup postgres and adminer
+    typer.echo(f"starting up database in localhost")
+    compose_file = Path.cwd() / "consistency" / "docker-compose.yml"
+    subprocess.run(
+        f"docker-compose --file {compose_file} up --detach",
+        shell=True,
+        check=True,
+        cwd=compose_file.parent,
+        env={**os.environ, **{"POSTGRES_DATA_VOLUME": postgres_volume_name}},
+    )
+    typer.echo(
+        f"database started: adminer available on http://127.0.0.1:18080/?pgsql=postgres&username={postgres_username}&db=simcoredb&ns=public"
+    )
+
+    # wait a bit that the dockers are up
+    # time.sleep(5)
+
+    db_file_paths = set()
+    # now the database is up, let's go through the projects table
+    with psycopg2.connect(
+        host="127.0.0.1",
+        port=5432,
+        database="simcoredb",
+        user=postgres_username,
+        password=postgres_password,
+    ) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT uuid, workbench"
+                ' FROM "projects"'
+                " INNER JOIN users"
+                " ON projects.prj_owner = users.id"
+                " WHERE users.role != 'GUEST'"
+            )
+            typer.echo(
+                f"found {cursor.rowcount} projects, now getting project/node ids..."
+            )
+            project_nodes = {}
+            rows = cursor.fetchall()
+            with typer.progressbar(rows) as progress:
+                for row in progress:
+                    project_uuid, workbench = row
+                    project_nodes[project_uuid] = list(workbench.keys())
+            typer.echo(
+                f"processed {cursor.rowcount} projects, now looking for files in the file_meta_data table..."
+            )
+
+            with typer.progressbar(project_nodes) as progress:
+                for project_uuid, node_ids in project_nodes.items():
+                    array = str([f"{project_uuid}/{n}%" for n in node_ids])
+
+                    if not node_ids:
+                        continue
+                    cursor.execute(
+                        "SELECT file_uuid"
+                        ' FROM "file_meta_data"'
+                        f" WHERE file_meta_data.file_uuid LIKE any (array{array}) AND location_id = '0'"
+                    )
+
+                    # here we got all the files for that project uuid/node_ids combination
+                    file_rows = cursor.fetchall()
+                    for file in file_rows:
+                        db_file_paths.add(file[0])
+                progress.update(1)
+
+    db_file_entries_path = Path.cwd() / "project_file_entries.txt"
+    db_file_entries_path.write_text("\n".join(db_file_paths))
+    typer.echo(
+        f"processed {len(project_nodes)} projects, found {len(db_file_paths)} file entries, saved in {db_file_entries_path}"
+    )
+
+    # ok now we need to connect to s3
+    typer.echo(
+        f"now connecting with S3 backend and getting file for {len(project_nodes)} projects..."
+    )
+    s3_file_entries = set()
+    with typer.progressbar(project_nodes) as progress:
+        for project_uuid in progress:
+            try:
+                completed_process = subprocess.run(
+                    f"docker run "
+                    f"--env MC_HOST_mys3='https://{s3_access}:{s3_secret}@{s3_endpoint}' "
+                    "minio/mc "
+                    f"ls --recursive mys3/{s3_bucket}/{project_uuid}/",
+                    shell=True,
+                    check=True,
+                    capture_output=True,
+                )
+                if completed_process.stdout != b"":
+                    # formatted as:
+                    # [2021-09-07 04:35:49 UTC] 1.5GiB 05e821d1-2b4b-455f-86b6-9e197545c1ad/work.tgz
+                    # DATE_creation? size node_id/file_path.ext
+                    list_of_files = completed_process.stdout.decode("UTF-8").split("\n")
+                    for file in list_of_files:
+                        s3_file_entries.add(re.findall(r".* (.+)", file))
+
+            except subprocess.CalledProcessError:
+                pass
+
+    import pdb
+
+    pdb.set_trace()
+
+    # file_found = set()
+    # file_missing = set()
+    # with typer.progressbar(db_file_paths) as progress:
+    #     for file_entry in progress:
+    #         try:
+    #             subprocess.run(
+    #                 f"docker run "
+    #                 f"--env MC_HOST_mys3='https://{s3_access}:{s3_secret}@{s3_endpoint}' "
+    #                 "minio/mc "
+    #                 f"ls --recursive mys3/{s3_bucket}/{file_entry}",
+    #                 shell=True,
+    #                 check=True,
+    #                 capture_output=True,
+    #             )
+    #             file_found.add(file_entry)
+    #         except subprocess.CalledProcessError:
+    #             file_missing.add(file_entry)
+
+    # typer.echo(
+    #     f"processed {len(db_file_paths)} files. found {len(file_found)}, missing {len(file_missing)}"
+    # )
+    # missing_files = Path.cwd() / "missing_files.txt"
+    # missing_files.write_text("\n".join(file_missing))
+
+
+if __name__ == "__main__":
+    typer.run(main)

--- a/scripts/maintenance/check_consistency_data.py
+++ b/scripts/maintenance/check_consistency_data.py
@@ -120,6 +120,7 @@ async def _get_files_from_s3_backend(
 ) -> Set[str]:
     s3_file_entries = set()
     try:
+        # TODO: this could probably run faster if we maintain the client, and run successive commands in there
         command = (
             f"docker run "
             f"--env MC_HOST_mys3='https://{s3_access}:{s3_secret}@{s3_endpoint}' "
@@ -211,7 +212,11 @@ async def main_async(
 
     common_files = db_file_entries.intersection(s3_file_entries)
     s3_missing_files = db_file_entries.difference(s3_file_entries)
+    s3_missing_files_path = Path.cwd() / "s3_missing_files.txt"
+    s3_missing_files_path.write_text("\n".join(s3_missing_files))
     db_missing_files = s3_file_entries.difference(db_file_entries)
+    db_missing_files_path = Path.cwd() / "db_missing_files.txt"
+    db_missing_files_path.write_text("\n".join(db_missing_files))
 
     typer.secho(
         f"{len(common_files)} files are the same in both system", fg=typer.colors.BLUE

--- a/scripts/maintenance/check_consistency_data.py
+++ b/scripts/maintenance/check_consistency_data.py
@@ -10,13 +10,213 @@
     4. connect to the S3 backend, check that these files exist
     5. generate a report with: project uuid, owner, files missing in S3
 """
+import asyncio
+import logging
 import os
 import re
 import subprocess
+from contextlib import asynccontextmanager
 from pathlib import Path
+from typing import Dict, List, Set
 
-import psycopg2
+import aiopg
 import typer
+from tenacity import after_log, retry, stop_after_attempt, wait_random
+
+log = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def managed_docker_compose(
+    postgres_volume_name: str, postgres_username: str, postgres_password: str
+):
+    typer.echo(f"starting up database in localhost")
+    compose_file = Path.cwd() / "consistency" / "docker-compose.yml"
+    try:
+        subprocess.run(
+            f"docker-compose --file {compose_file} up --detach",
+            shell=True,
+            check=True,
+            cwd=compose_file.parent,
+            env={**os.environ, **{"POSTGRES_DATA_VOLUME": postgres_volume_name}},
+        )
+        typer.echo(
+            f"database started: adminer available on http://127.0.0.1:18080/?pgsql=postgres&username={postgres_username}&db=simcoredb&ns=public"
+        )
+
+        @retry(
+            wait=wait_random(1, 3),
+            stop=stop_after_attempt(10),
+            after=after_log(log, logging.WARN),
+        )
+        async def postgres_responsive():
+            async with aiopg.create_pool(
+                f"dbname=simcoredb user={postgres_username} password={postgres_password} host=127.0.0.1"
+            ) as pool:
+                async with pool.acquire() as conn:
+                    async with conn.cursor() as cur:
+                        await cur.execute("SELECT 1")
+
+        await postgres_responsive()
+        yield
+    finally:
+        subprocess.run(
+            f"docker-compose --file {compose_file} down",
+            shell=True,
+            check=True,
+            cwd=compose_file.parent,
+        )
+
+
+async def _get_projects_nodes(pool) -> Dict[str, List[str]]:
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            await cursor.execute(
+                "SELECT uuid, workbench"
+                ' FROM "projects"'
+                " INNER JOIN users"
+                " ON projects.prj_owner = users.id"
+                " WHERE users.role != 'GUEST'"
+            )
+            typer.secho(
+                f"found {cursor.rowcount} projects, now getting project/node ids..."
+            )
+            project_db_rows = await cursor.fetchall()
+        project_nodes = {
+            project_uuid: list(workbench.keys())
+            for project_uuid, workbench in project_db_rows
+            if workbench
+        }
+        typer.echo(
+            f"processed {cursor.rowcount} projects, now looking for files in the file_meta_data table..."
+        )
+        return project_nodes
+
+
+async def _get_files_from_project_nodes(
+    pool, project_uuid: str, node_ids: List[str]
+) -> Set[str]:
+    async with pool.acquire() as conn:
+        async with conn.cursor() as cursor:
+            array = str([f"{project_uuid}/{n}%" for n in node_ids])
+            await cursor.execute(
+                "SELECT file_uuid"
+                ' FROM "file_meta_data"'
+                f" WHERE file_meta_data.file_uuid LIKE any (array{array}) AND location_id = '0'"
+            )
+
+            # here we got all the files for that project uuid/node_ids combination
+            file_rows = await cursor.fetchall()
+            return {file[0] for file in file_rows}
+
+
+async def _get_files_from_s3_backend(
+    s3_endpoint: str,
+    s3_access: str,
+    s3_secret: str,
+    s3_bucket: str,
+    project_uuid: str,
+    progress,
+) -> Set[str]:
+    s3_file_entries = set()
+    try:
+        completed_process = subprocess.run(
+            f"docker run "
+            f"--env MC_HOST_mys3='https://{s3_access}:{s3_secret}@{s3_endpoint}' "
+            "minio/mc "
+            f"ls --recursive mys3/{s3_bucket}/{project_uuid}/",
+            shell=True,
+            check=True,
+            capture_output=True,
+        )
+        if completed_process.stdout != b"":
+            # formatted as:
+            # [2021-09-07 04:35:49 UTC] 1.5GiB 05e821d1-2b4b-455f-86b6-9e197545c1ad/work.tgz
+            # DATE_creation? size node_id/file_path.ext
+            list_of_files = completed_process.stdout.decode("UTF-8").split("\n")
+            for file in list_of_files:
+                match = re.findall(r".* (.+)", file)
+                if match:
+                    s3_file_entries.add(f"{project_uuid}/{match[0]}")
+
+    except subprocess.CalledProcessError:
+        pass
+    progress.update(1)
+    return s3_file_entries
+
+
+async def main_async(
+    postgres_volume_name: str,
+    postgres_username: str,
+    postgres_password: str,
+    s3_endpoint: str,
+    s3_access: str,
+    s3_secret: str,
+    s3_bucket: str,
+):
+
+    async with managed_docker_compose(
+        postgres_volume_name, postgres_username, postgres_password
+    ):
+        # now the database is up, let's get all the projects owned by a non-GUEST account
+        async with aiopg.create_pool(
+            f"dbname=simcoredb user={postgres_username} password={postgres_password} host=127.0.0.1"
+        ) as pool:
+            project_nodes = await _get_projects_nodes(pool)
+            # Rationale: the project database does not contain all the files in a node (logs, state files are missing)
+            # Therefore, we will list here all the files that are registered in the file_meta_data table using the same projectid/nodeid
+            all_sets_of_file_entries = await asyncio.gather(
+                *[
+                    _get_files_from_project_nodes(pool, project_uuid, node_ids)
+                    for project_uuid, node_ids in project_nodes.items()
+                ]
+            )
+    db_file_entries = set().union(*all_sets_of_file_entries)
+    db_file_entries_path = Path.cwd() / "project_file_entries.txt"
+    db_file_entries_path.write_text("\n".join(db_file_entries))
+    typer.secho(
+        f"processed {len(project_nodes)} projects, found {len(db_file_entries)} file entries, saved in {db_file_entries_path}",
+        fg=typer.colors.YELLOW,
+    )
+
+    # let's proceed with S3 backend: files are saved in BUCKET_NAME/projectID/nodeID/fileA.ext
+    # Rationale: Similarly we list here all the files in each of the projects. And it goes faster to list them recursively.
+    typer.echo(
+        f"now connecting with S3 backend and getting files for {len(project_nodes)} projects..."
+    )
+    with typer.progressbar(length=len(project_nodes)) as progress:
+        all_sets_in_s3 = await asyncio.gather(
+            *[
+                _get_files_from_s3_backend(
+                    s3_endpoint, s3_access, s3_secret, s3_bucket, project_uuid, progress
+                )
+                for project_uuid in project_nodes
+            ]
+        )
+    s3_file_entries = set().union(*all_sets_in_s3)
+    s3_file_entries_path = Path.cwd() / "s3_file_entries.txt"
+    s3_file_entries_path.write_text("\n".join(s3_file_entries))
+    typer.echo(
+        f"processed {len(project_nodes)} projects, found {len(s3_file_entries)} file entries, saved in {s3_file_entries_path}"
+    )
+
+    typer.echo(
+        f"Refining differences between DB:{len(db_file_entries)} files and S3:{len(s3_file_entries)} files..."
+    )
+
+    common_files = db_file_entries.intersection(s3_file_entries)
+    s3_missing_files = db_file_entries.difference(s3_file_entries)
+    db_missing_files = s3_file_entries.difference(db_file_entries)
+
+    typer.secho(
+        f"{len(common_files)} files are the same in both system", fg=typer.colors.BLUE
+    )
+    typer.secho(
+        f"{len(s3_missing_files)} files are the missing in S3", fg=typer.colors.RED
+    )
+    typer.secho(
+        f"{len(db_missing_files)} files are the missing in DB", fg=typer.colors.RED
+    )
 
 
 def main(
@@ -28,137 +228,17 @@ def main(
     s3_secret: str,
     s3_bucket: str,
 ):
-    # setup postgres and adminer
-    typer.echo(f"starting up database in localhost")
-    compose_file = Path.cwd() / "consistency" / "docker-compose.yml"
-    subprocess.run(
-        f"docker-compose --file {compose_file} up --detach",
-        shell=True,
-        check=True,
-        cwd=compose_file.parent,
-        env={**os.environ, **{"POSTGRES_DATA_VOLUME": postgres_volume_name}},
+    asyncio.run(
+        main_async(
+            postgres_volume_name,
+            postgres_username,
+            postgres_password,
+            s3_endpoint,
+            s3_access,
+            s3_secret,
+            s3_bucket,
+        )
     )
-    typer.echo(
-        f"database started: adminer available on http://127.0.0.1:18080/?pgsql=postgres&username={postgres_username}&db=simcoredb&ns=public"
-    )
-
-    # wait a bit that the dockers are up
-    # time.sleep(5)
-
-    db_file_paths = set()
-    # now the database is up, let's go through the projects table
-    with psycopg2.connect(
-        host="127.0.0.1",
-        port=5432,
-        database="simcoredb",
-        user=postgres_username,
-        password=postgres_password,
-    ) as conn:
-        with conn.cursor() as cursor:
-            cursor.execute(
-                "SELECT uuid, workbench"
-                ' FROM "projects"'
-                " INNER JOIN users"
-                " ON projects.prj_owner = users.id"
-                " WHERE users.role != 'GUEST'"
-            )
-            typer.echo(
-                f"found {cursor.rowcount} projects, now getting project/node ids..."
-            )
-            project_nodes = {}
-            rows = cursor.fetchall()
-            with typer.progressbar(rows) as progress:
-                for row in progress:
-                    project_uuid, workbench = row
-                    project_nodes[project_uuid] = list(workbench.keys())
-            typer.echo(
-                f"processed {cursor.rowcount} projects, now looking for files in the file_meta_data table..."
-            )
-
-            with typer.progressbar(project_nodes) as progress:
-                for project_uuid, node_ids in project_nodes.items():
-                    array = str([f"{project_uuid}/{n}%" for n in node_ids])
-
-                    if not node_ids:
-                        continue
-                    cursor.execute(
-                        "SELECT file_uuid"
-                        ' FROM "file_meta_data"'
-                        f" WHERE file_meta_data.file_uuid LIKE any (array{array}) AND location_id = '0'"
-                    )
-
-                    # here we got all the files for that project uuid/node_ids combination
-                    file_rows = cursor.fetchall()
-                    for file in file_rows:
-                        db_file_paths.add(file[0])
-                progress.update(1)
-
-    db_file_entries_path = Path.cwd() / "project_file_entries.txt"
-    db_file_entries_path.write_text("\n".join(db_file_paths))
-    typer.echo(
-        f"processed {len(project_nodes)} projects, found {len(db_file_paths)} file entries, saved in {db_file_entries_path}"
-    )
-
-    # ok now we need to connect to s3
-    typer.echo(
-        f"now connecting with S3 backend and getting file for {len(project_nodes)} projects..."
-    )
-    s3_file_entries = set()
-    with typer.progressbar(project_nodes) as progress:
-        for project_uuid in progress:
-            try:
-                completed_process = subprocess.run(
-                    f"docker run "
-                    f"--env MC_HOST_mys3='https://{s3_access}:{s3_secret}@{s3_endpoint}' "
-                    "minio/mc "
-                    f"ls --recursive mys3/{s3_bucket}/{project_uuid}/",
-                    shell=True,
-                    check=True,
-                    capture_output=True,
-                )
-                if completed_process.stdout != b"":
-                    # formatted as:
-                    # [2021-09-07 04:35:49 UTC] 1.5GiB 05e821d1-2b4b-455f-86b6-9e197545c1ad/work.tgz
-                    # DATE_creation? size node_id/file_path.ext
-                    list_of_files = completed_process.stdout.decode("UTF-8").split("\n")
-                    for file in list_of_files:
-                        partial_file_path = re.findall(r".* (.+)", file)
-                        s3_file_entries.add(f"{project_uuid}/{partial_file_path}")
-
-            except subprocess.CalledProcessError:
-                pass
-    s3_file_entries_path = Path.cwd() / "s3_file_entries.txt"
-    s3_file_entries_path.write_text("\n".join(s3_file_entries))
-    typer.echo(
-        f"processed {len(project_nodes)} projects, found {len(s3_file_entries)} file entries, saved in {s3_file_entries_path}"
-    )
-    import pdb
-
-    pdb.set_trace()
-
-    # file_found = set()
-    # file_missing = set()
-    # with typer.progressbar(db_file_paths) as progress:
-    #     for file_entry in progress:
-    #         try:
-    #             subprocess.run(
-    #                 f"docker run "
-    #                 f"--env MC_HOST_mys3='https://{s3_access}:{s3_secret}@{s3_endpoint}' "
-    #                 "minio/mc "
-    #                 f"ls --recursive mys3/{s3_bucket}/{file_entry}",
-    #                 shell=True,
-    #                 check=True,
-    #                 capture_output=True,
-    #             )
-    #             file_found.add(file_entry)
-    #         except subprocess.CalledProcessError:
-    #             file_missing.add(file_entry)
-
-    # typer.echo(
-    #     f"processed {len(db_file_paths)} files. found {len(file_found)}, missing {len(file_missing)}"
-    # )
-    # missing_files = Path.cwd() / "missing_files.txt"
-    # missing_files.write_text("\n".join(file_missing))
 
 
 if __name__ == "__main__":

--- a/scripts/maintenance/consistency/docker-compose.yml
+++ b/scripts/maintenance/consistency/docker-compose.yml
@@ -1,0 +1,49 @@
+version: "3.8"
+services:
+  postgres:
+    image: "postgres:10.11@sha256:2aef165ab4f30fbb109e88959271d8b57489790ea13a77d27c02d8adb8feb20f"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    init: true
+    environment:
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: test
+      POSTGRES_HOST: 127.0.0.1
+      POSTGRES_PORT: 5432
+    ports:
+      - "5432:5432"
+    # https://www.postgresql.org/docs/10/runtime-config-logging.html#GUC-LOG-STATEMENT
+    command:
+      [
+        "postgres",
+        "-c",
+        "log_connections=true",
+        "-c",
+        "log_disconnections=true",
+        "-c",
+        "log_duration=true",
+        "-c",
+        "log_line_prefix=[%p] [%a] [%c] [%x] ",
+        "-c",
+        "tcp_keepalives_idle=600",
+        "-c",
+        "tcp_keepalives_interval=600",
+        "-c",
+        "tcp_keepalives_count=5",
+      ]
+  adminer:
+    image: adminer:4.8.0
+    init: true
+    environment:
+      - ADMINER_DEFAULT_SERVER=postgres
+      - ADMINER_DESIGN=nette
+      - ADMINER_PLUGINS=json-column
+    ports:
+      - 18080:8080
+    depends_on:
+      - postgres
+
+volumes:
+  postgres_data:
+    name: ${POSTGRES_DATA_VOLUME}

--- a/scripts/maintenance/requirements.txt
+++ b/scripts/maintenance/requirements.txt
@@ -1,5 +1,6 @@
 black
 httpx
+psycopg2-binary
 pydantic[email,dotenv]
 pylint
 typer[all]

--- a/scripts/maintenance/requirements.txt
+++ b/scripts/maintenance/requirements.txt
@@ -1,6 +1,8 @@
+aiopg
 black
 httpx
 psycopg2-binary
 pydantic[email,dotenv]
 pylint
+tenacity
 typer[all]


### PR DESCRIPTION
Super nice and useful scripts!

A few  suggestion:
- DONE: dump data in csv files with headers (can be opened and explored in excel-like)
- DONE: in ``s3_missing_files.csv`` add columns with file size and last modification date (see below). This helps to explore the consistency
- add ``docker pull mino/cl`` before doing requests to s3. otherwise captured stdout is polluted with log message from pulling instead of the client responses
- EXTRA: prompt passwords/secret instead of passing them as arguments. This way they do not remain in the history.
- EXTRA: option to use dumped files as cache instead of re-running requests

![image](https://user-images.githubusercontent.com/32402063/132503260-144b3829-66cf-460f-98b6-642a974518f4.png)